### PR TITLE
Fix leaderboard API loading

### DIFF
--- a/Tailspin.SpaceGame.Web/LeaderboardFunctionClient/LeaderboardFunctionClient.cs
+++ b/Tailspin.SpaceGame.Web/LeaderboardFunctionClient/LeaderboardFunctionClient.cs
@@ -21,7 +21,8 @@ namespace TailSpin.SpaceGame.Web
             using (WebClient webClient = new WebClient())
             {
                 string json = await webClient.DownloadStringTaskAsync($"{this._functionUrl}?page={page}&pageSize={pageSize}&mode={mode}&region={region}");
-                return JsonSerializer.Deserialize<LeaderboardResponse>(json);
+                var leaderboardResponse = JsonSerializer.Deserialize<LeaderboardResponse>(json, new JsonSerializerOptions { IncludeFields = true });
+                return leaderboardResponse;
             }
         }
     }

--- a/Tailspin.SpaceGame.Web/LeaderboardFunctionClient/LeaderboardResponse.cs
+++ b/Tailspin.SpaceGame.Web/LeaderboardFunctionClient/LeaderboardResponse.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using TailSpin.SpaceGame.Web.Models;
 
 namespace TailSpin.SpaceGame.Web
@@ -6,17 +7,24 @@ namespace TailSpin.SpaceGame.Web
     public class LeaderboardResponse
     {
         // The game mode selected in the view.
+        [JsonPropertyName("selectedMode")]
         public string SelectedMode { get; set; }
+
         // The game region (map) selected in the view.
+        [JsonPropertyName("selectedRegion")]
         public string SelectedRegion { get; set; }
         // The current page to be shown in the view.
+        [JsonPropertyName("page")]
         public int Page { get; set; }
         // The number of items to show per page in the view.
+        [JsonPropertyName("pageSize")]
         public int PageSize { get; set; }
 
         // The scores to display in the view.
+        [JsonPropertyName("scores")]
         public IEnumerable<ScoreProfile> Scores { get; set; }
         // The total number of results for the selected game mode and region in the view.
+        [JsonPropertyName("totalResults")]
         public int TotalResults { get; set; }
     }
 }

--- a/Tailspin.SpaceGame.Web/Models/LeaderboardViewModel.cs
+++ b/Tailspin.SpaceGame.Web/Models/LeaderboardViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace TailSpin.SpaceGame.Web.Models
 {
@@ -44,8 +45,10 @@ namespace TailSpin.SpaceGame.Web.Models
     public struct ScoreProfile
     {
         // The player's score.
+        [JsonPropertyName("score")]
         public Score Score;
         // The player's profile.
+        [JsonPropertyName("profile")]
         public Profile Profile;
     }
 }


### PR DESCRIPTION
Following the [Automate multi-container Kubernetes deployments with Azure Pipelines](https://docs.microsoft.com/en-us/learn/modules/deploy-kubernetes/) module, when I reached to the last step, the Leaderboard API was working fine, but the web couldn't be displayed because an error.

![image](https://user-images.githubusercontent.com/17756717/123658069-62d9b800-d7ff-11eb-9a61-2785d1149fc4.png)

I debugged the application locally and found a few issues related to the `LeaderboardResponse` *deserialization*:
1. `JsonPropertyName` attributes are missing in `LeaderboardResponse` class, so when `JsonSerializer` try to deserialize it, just returns `0` or `null` values.
2. `JsonPropertyName` attributes are missing in `ScoreProfile` struct, so when `JsonSerializer` try to deserialize the `LeaderBoard.Scores` property just returns null values.
3. The `ScoreProfile` struct use `Score` and `Profile` as fields, not properties. So, JsonSerializer must be configured to `IncludeFields = true`, otherwise the returned value for `Score` and `Profile` is null.
